### PR TITLE
Make the ball move after it has been generated

### DIFF
--- a/Encryption Bingo/Assets/encryptionBingoScript.cs
+++ b/Encryption Bingo/Assets/encryptionBingoScript.cs
@@ -147,6 +147,7 @@ public class encryptionBingoScript : MonoBehaviour {
         else
         {
             ChooseBall();
+            StartCoroutine(ComeHereBall());
         }
     }
 

--- a/Encryption Bingo/Assets/encryptionBingoScript.cs
+++ b/Encryption Bingo/Assets/encryptionBingoScript.cs
@@ -283,10 +283,12 @@ public class encryptionBingoScript : MonoBehaviour {
                 if (done == true)
                 {
                     ChooseBall();
+                    StartCoroutine(ComeHereBall());
                 }
                 else if (balls > 0)
                 {
                     ChooseBall();
+                    StartCoroutine(ComeHereBall());
                 }
                 else
                 {
@@ -298,6 +300,7 @@ public class encryptionBingoScript : MonoBehaviour {
         {
             incorrect = false;
             ChooseBall();
+            StartCoroutine(ComeHereBall());
         }
     }
 
@@ -312,7 +315,6 @@ public class encryptionBingoScript : MonoBehaviour {
         }
         else
         {
-            StartCoroutine(ComeHereBall());
             if (balls == 0 && !done)
             {
                 stageDone = false;


### PR DESCRIPTION
The ball can glitch out if it needs to be regenrated while it is rolling or after a strike. This update ensures that the ball will start rolling after it has been generated. 